### PR TITLE
Bugfix/fix keystore name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ module "kafka" {
   bastion_host      = "bastion.host"
   user              = "ronswanson"
   private_key       = file("~/.ssh/dec.key")
-  user_groups       = ["ronswanson", "poc"]a
-  mm2_prpoperties   = "~/mm2.properties"
+  user_groups       = ["ronswanson", "poc"]
+  mm2_properties   = "~/mm2.properties"
 
   trust_store   = {
     truststore = "./kafkatruststore.jks"

--- a/containter_host.tf
+++ b/containter_host.tf
@@ -68,7 +68,7 @@ resource "null_resource" "cluster" {
   }
   
   provisioner "file" {
-    source      = var.mm2_prpoperties
+    source      = var.mm2_properties
     destination = "/home/${var.user}/mm2.properties"
   }
 

--- a/containter_host.tf
+++ b/containter_host.tf
@@ -64,7 +64,7 @@ resource "null_resource" "cluster" {
 
   provisioner "file" {
     source      = var.key_store.keystore
-    destination = "/home/${var.user}/mm_keystore.jks"
+    destination = "/home/${var.user}/mm.keystore.jks"
   }
   
   provisioner "file" {

--- a/variables.tf
+++ b/variables.tf
@@ -65,7 +65,7 @@ variable "key_store" {
   )
 }
 
-variable "mm2_prpoperties" {
+variable "mm2_properties" {
   description = "mm2 properties file path"
   type      = string
 }


### PR DESCRIPTION
Fixes the issue where mm.keystore.jks was put into the containerhost as mm_keystore.jks and thus not added to the volume.
Fixes a typo in the sample
Fixes a typo in the mm2_properties variable.